### PR TITLE
feat: extract landing nav controls

### DIFF
--- a/client/src/components/LandingNavControls.jsx
+++ b/client/src/components/LandingNavControls.jsx
@@ -1,0 +1,79 @@
+/**
+ * @file LandingNavControls.jsx
+ * @author Alex Kachur
+ * @since 2025-11-11
+ * @purpose Provides reusable hamburger menu + drawer.
+ */
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { PRIMARY_NAV_LINKS } from '../utils/navigation.js';
+
+/**
+ * Renders the hamburger trigger, backdrop, and slide-out drawer used on landing pages.
+ * @param {Object} props component props
+ * @param {string} [props.drawerId] optional DOM id for the drawer element
+ * @param {boolean} [props.hideButtonWhenOpen] hide the hamburger while the drawer is open
+ * @returns {JSX.Element}
+ */
+export default function LandingNavControls({
+  drawerId = 'landing-drawer',
+  hideButtonWhenOpen = false,
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const toggleMenu = () => setMenuOpen((value) => !value);
+  const closeMenu = () => setMenuOpen(false);
+
+  return (
+    <>
+      <header className="landing-basic__chrome">
+        {menuOpen && hideButtonWhenOpen ? null : (
+          <button
+            type="button"
+            className="landing-basic__menu"
+            aria-label="Open navigation"
+            aria-controls={drawerId}
+            aria-expanded={menuOpen}
+            onClick={toggleMenu}
+          >
+            <span />
+            <span />
+            <span />
+          </button>
+        )}
+      </header>
+
+      {menuOpen ? (
+        <button
+          type="button"
+          className="landing-basic__backdrop"
+          aria-label="Close menu"
+          onClick={closeMenu}
+        />
+      ) : null}
+
+      <nav
+        id={drawerId}
+        className={`landing-basic__drawer${menuOpen ? ' landing-basic__drawer--open' : ''}`}
+        aria-hidden={!menuOpen}
+      >
+        <button
+          type="button"
+          className="landing-basic__drawer-close"
+          onClick={closeMenu}
+          aria-label="Close menu"
+        >
+          ×
+        </button>
+        <ul className="landing-basic__drawer-list">
+          {PRIMARY_NAV_LINKS.map((link) => (
+            <li key={link.path}>
+              <Link to={link.path} onClick={closeMenu}>
+                {link.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -4,32 +4,13 @@
  * @since 2025-11-05
  * @purpose Temporary full-screen landing with brand logo and primary CTAs.
  */
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { PRIMARY_NAV_LINKS } from '../utils/navigation';
+import LandingNavControls from '../components/LandingNavControls.jsx';
 
 export default function Home() {
-  const [menuOpen, setMenuOpen] = useState(false);
-
-  const toggleMenu = () => setMenuOpen((v) => !v);
-  const closeMenu = () => setMenuOpen(false);
-
   return (
     <div className="landing-basic">
-      <header className="landing-basic__chrome">
-        <button
-          type="button"
-          className="landing-basic__menu"
-          aria-label="Open navigation"
-          aria-controls="landing-drawer"
-          aria-expanded={menuOpen}
-          onClick={toggleMenu}
-        >
-          <span />
-          <span />
-          <span />
-        </button>
-      </header>
+      <LandingNavControls />
 
       <main className="landing-basic__body">
         <img
@@ -55,28 +36,6 @@ export default function Home() {
         COMPLETED: Routed play button to /sessions (active sessions page). Completed by Kelly Burden - Nov 2025*/}
       </main>
 
-      {/* Simple slide-out drawer for quick navigation while on the landing view. */}
-      {/* TODO (Frontend): read links from PRIMARY_NAV_LINKS to avoid duplicating routes here. 
-      COMPLETED: Implemented dynamic navigation links from PRIMARY_NAV_LINKS. Completed by Kelly Burden - Nov 2025 */}
-      {menuOpen ? <button className="landing-basic__backdrop" aria-label="Close menu" onClick={closeMenu} /> : null}
-      <nav
-        id="landing-drawer"
-        className={"landing-basic__drawer" + (menuOpen ? " landing-basic__drawer--open" : "")}
-        aria-hidden={!menuOpen}
-      >
-        <button type="button" className="landing-basic__drawer-close" onClick={closeMenu} aria-label="Close menu">
-          ×
-        </button>
-        <ul className="landing-basic__drawer-list">
-          {PRIMARY_NAV_LINKS.map(link => (
-            <li key={link.path}>
-              <Link to={link.path} onClick={closeMenu}>
-                {link.label}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </nav>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extract the hamburger menu and drawer logic into `LandingNavControls` so landing-style screens reuse a single component
- refactor `Home.jsx` to consume the shared control instead of maintaining its own nav state
- document the shared nav controls for future landing pages

## Testing
- `npm run build` (client)
