### PR TITLE
chore(router): use hash router fallback

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,7 +4,7 @@
  * @since 2025-11-04
  * @purpose Hosts the Family Feud routing structure and shared layout.
  */
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout.jsx';
 import Home from './pages/Home.jsx';
 import Dashboard from './pages/Dashboard.jsx';
@@ -19,8 +19,9 @@ import SignedOut from './pages/SignedOut.jsx';
 import GameBoard from './pages/GameBoard.jsx';
 
 export default function App() {
+  // TODO: Swap Router alias back to BrowserRouter once the server serves index.html for deep links.
   return (
-    <BrowserRouter>
+    <Router>
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
@@ -36,6 +37,6 @@ export default function App() {
         </Route>
         <Route path="/game-board" element={<GameBoard />} />
       </Routes>
-    </BrowserRouter>
+    </Router>
   );
 }


### PR DESCRIPTION
## Summary
- swap the SPA Router to `HashRouter` temporarily so deep links like `/game-board` survive hard refreshes on Render
- keep the routing structure intact and add a TODO noting we can revert to `BrowserRouter` once the server serves `index.html` for unknown routes
- rebuild the client bundle to verify the hash-based navigation still compiles cleanly

## Why
Refreshing `https://familyfeud-client.onrender.com/game-board` returned the platform 404 because the backend doesn’t rewrite unknown paths to `index.html`. Using hashes keeps users in-session without needing new backend config.

## Testing
- `npm run build --prefix client`
