### PR TITLE
Harden backend auth and AI handling

### DIFF
--- a/server/controllers/gameSession.controller.js
+++ b/server/controllers/gameSession.controller.js
@@ -2,6 +2,11 @@ import ActiveSessionModel from '../models/activeSession.model.js';
 import QuestionModel from '../models/question.model.js';
 import { ROUND_BUCKETS } from './question.controller.js';
 
+const findTeamById = (session, teamId) =>
+  session?.teams?.find((team) =>
+    team?._id?.toString() === teamId || team?.id === teamId
+  );
+
 // Create a new game session
 export const createGameSession = async (req, res) => {
   try {
@@ -98,7 +103,7 @@ export const updateTeam = async (req, res) => {
     const session = await ActiveSessionModel.findOne({ id });
     if (!session) return res.status(404).json({ message: 'Session not found' });
 
-    const team = session.teams.id(teamId);
+    const team = findTeamById(session, teamId);
     if (!team) return res.status(404).json({ message: 'Team not found' });
 
     if (score !== undefined) team.score = score;
@@ -150,7 +155,7 @@ export const addStrike = async (req, res) => {
     const session = await ActiveSessionModel.findOne({ id });
     if (!session) return res.status(404).json({ message: 'Session not found' });
 
-    const team = session.teams.id(teamId);
+    const team = findTeamById(session, teamId);
     if (!team) return res.status(404).json({ message: 'Team not found' });
 
     team.strikes += 1;
@@ -171,7 +176,7 @@ export const awardPoints = async (req, res) => {
     const session = await ActiveSessionModel.findOne({ id });
     if (!session) return res.status(404).json({ message: 'Session not found' });
 
-    const team = session.teams.id(teamId);
+    const team = findTeamById(session, teamId);
     if (!team) return res.status(404).json({ message: 'Team not found' });
 
     team.score += points;

--- a/server/middlewares/auth.middleware.js
+++ b/server/middlewares/auth.middleware.js
@@ -13,21 +13,21 @@ const requireSignin = async (req, res, next) => {
   else if (req.cookies.t)
     token = req.cookies.t;
 
-  if (!token) return res.json({ valid: false, user: null });
+  if (!token) return res.status(401).json({ valid: false, user: null });
 
   try {
     const
       decode = jwt.verify(token, process.env.JWT_SECRET),
       user = await User.findById(decode._id).select('-password');
 
-    if (!user) return res.json({ valid: false, user: null });
+    if (!user) return res.status(401).json({ valid: false, user: null });
 
     req.auth = decode;
     req.user = user;
     next();
   }
   catch (_) {
-    return res.json({ valid: false, user: null });
+    return res.status(401).json({ valid: false, user: null });
   };
 };
 


### PR DESCRIPTION
# Summary
- Use `GEMINI_API_KEY` and harden AI handling: instantiate the Gemini client with the key, safely parse `response.text`, and log detailed errors instead of failing silently.
- Tighten auth responses: missing/invalid JWTs now return 401 while preserving the `{ valid: false, user: null }` payload for clients.
- Make session team updates resilient: resolve teams by custom `id` or subdoc `_id` so strike/score mutations work reliably.
- Align question-set controller with the `answers` schema: normalize updates, add/remove answer entries, and run validators on update (remove obsolete `questionIds` logic).
