### PR TITLE
feat(game): stabilize multiplayer flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -19,6 +19,7 @@ import QuestionSets from './pages/QuestionSets.jsx';
 import SessionCreate from './pages/SessionCreate.jsx';
 import Leaderboard from './pages/Leaderboard.jsx';
 import GameBoard from './pages/GameBoard.jsx';
+import Lobby from './pages/Lobby.jsx';
 import UserProfile from './pages/UserProfile.jsx';
 
 import NotFound from './pages/NotFound.jsx';
@@ -36,6 +37,7 @@ export default function App() {
             <Route path="dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
             <Route path="question-sets" element={<ProtectedRoute><QuestionSets /></ProtectedRoute>} />
             <Route path="/game-board" element={<ProtectedRoute><GameBoard /></ProtectedRoute>} />
+            <Route path="lobby/:sessionId" element={<ProtectedRoute><Lobby /></ProtectedRoute>} />
             <Route path="session-create" element={<ProtectedRoute><SessionCreate /></ProtectedRoute>} />
             <Route path="leaderboard" element={<ProtectedRoute><Leaderboard /></ProtectedRoute>} />
             <Route path="signin" element={<SignIn />} />

--- a/client/src/pages/GameBoard.jsx
+++ b/client/src/pages/GameBoard.jsx
@@ -4,8 +4,8 @@
  * @since 2025-11-11
  * @purpose Interactive Family Feud board prototype that now delegates game logic to the gameplay engine.
  */
-import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { io } from 'socket.io-client';
 
@@ -13,6 +13,7 @@ import { useAuth } from '../components/auth/AuthContext.js';
 import useGameBoardEngine from '../gameplay/useGameBoardEngine.js';
 
 import { PRIMARY_NAV_LINKS } from '../utils/navigation.js';
+import { sessions } from '../utils/api.js';
 import {
   ANSWER_CARD_ASSET,
   ANSWERING_PHASES,
@@ -24,53 +25,216 @@ import {
   TIMER_CARD_ASSET,
 } from '../gameplay/gameBoardConstants.js';
 import AdminDrawer from '../components/AdminDrawer.jsx';
+import { apiFetch } from '../utils/api.js';
 
-const SERVER_URL = import.meta.env.PROD ? (import.meta.env.VITE_SERVER_URL || '') : (import.meta.env.VITE_LOCAL_URL || '');
+const SERVER_URL = import.meta.env.PROD
+  ? (import.meta.env.VITE_SERVER_URL || '')
+  : (import.meta.env.VITE_LOCAL_URL || 'http://localhost:3000');
+
+const flattenPlayers = (session) => {
+  if (session?.teams?.length) {
+    return session.teams.flatMap((team, idx) =>
+      (team.players || []).map((p, i) => ({
+        label: team.name || `Team ${idx + 1}`,
+        playerName: p.name || `Player ${i + 1}`,
+        avatar: PLAYER_PLACEHOLDERS[0].avatar,
+        scoreCard: PLAYER_PLACEHOLDERS[0].scoreCard,
+        teamId: team.id,
+        playerId: p.id
+      }))
+    );
+  }
+  return [];
+};
+
+const buildSessionState = (session, players) => {
+  if (!session) return null;
+    // Map team scores to player slots; fallback to zeroes.
+    const scores = players.map((p, idx) => {
+      const teamId = p.teamId;
+    const team = (session.teams || []).find((t) => t.id === teamId) || session.teams?.[idx];
+    return team?.score ?? 0;
+  });
+  // Choose strikes for active control team if present; fallback to max strikes.
+  const controlTeam = session.controlTeamId
+    ? (session.teams || []).find((t) => t.id === session.controlTeamId)
+    : null;
+  const strikes = controlTeam?.strikes ?? Math.max(0, ...(session.teams || []).map((t) => t.strikes || 0));
+    const controlIndex = session.controlTeamId
+      ? players.findIndex((p) => p.teamId === session.controlTeamId)
+      : null;
+    const activePlayerIndex = session.activePlayerId
+      ? players.findIndex((p) => p.playerId === session.activePlayerId)
+      : null;
+    return { scores, strikes, controlIndex, activePlayerIndex, revealedAnswers: session.revealedAnswers || [] };
+  };
+
+const deriveAnnouncement = (session) => {
+  if (!session) return '';
+  const findTeamName = (teamId) =>
+    (session.teams || []).find((t) => t.id === teamId)?.name || 'Team';
+  const findPlayerTeam = (playerId) =>
+    (session.teams || []).find((t) => (t.players || []).some((p) => p.id === playerId));
+  if (session.activePlayerId && !session.controlTeamId) {
+    const team = findPlayerTeam(session.activePlayerId);
+    return `${team?.name || 'Team'} buzzed first—answer now!`;
+  }
+  if (session.controlTeamId) {
+    return `${findTeamName(session.controlTeamId)} controls the board.`;
+  }
+  return '';
+};
 
 
 export default function GameBoard() {
-
+  const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get('sessionId') || 'demo-room-id';
   const { user } = useAuth();
+  const isActualAdmin = Boolean(user?.admin);
+  const navigate = useNavigate();
 
   const [menuOpen, setMenuOpen] = useState(false);
   const toggleMenu = () => setMenuOpen((value) => !value);
   const closeMenu = () => setMenuOpen(false);
 
-  // WebSocket instance
-  // TODO: 
-  const roomId = "demo-room-id"; // Replace with actual room ID
+  const [session, setSession] = useState(null);
+  const [initialRound, setInitialRound] = useState(null);
+  const [lastQuestionId, setLastQuestionId] = useState(null);
+  const [sessionState, setSessionState] = useState(null);
+  const [connectedUsers, setConnectedUsers] = useState([]);
+  const [loadStatus, setLoadStatus] = useState({ state: 'loading', message: '' });
+  const [socketStatus, setSocketStatus] = useState('connected');
+  const [actionStatus, setActionStatus] = useState({ state: 'idle', message: '' });
+  const [announcement, setAnnouncement] = useState('');
 
-  const [connectedUsers, setConnectedUsers] = useState({});
-
-  let websocket;
-
-  useEffect(() => {
-    websocket = io(SERVER_URL);
-
-    websocket.on('connect', () => {
-      console.log('Connected to WebSocket server with ID:', websocket.id);
-    });
-
-    if (user) websocket.emit('joinRoom', roomId, user, (res, resUser) => {
-      console.log(res);
-      setConnectedUsers((prevUsers) => ({ ...prevUsers, [resUser._id]: resUser }));
-    });
-  }, []);
-
-  // Above is for Websocket testing purposes only.
+  const websocketRef = useRef(null);
+  const [endStatus, setEndStatus] = useState({ state: 'idle', message: '' });
 
   const players = useMemo(() => {
+    if (session?.teams?.length) {
+      const flattened = session.teams.flatMap((team, idx) =>
+        (team.players || []).map((p, i) => ({
+          label: team.name || `Team ${idx + 1}`,
+          playerName: p.name || `Player ${i + 1}`,
+          avatar: PLAYER_PLACEHOLDERS[0].avatar,
+          scoreCard: PLAYER_PLACEHOLDERS[0].scoreCard,
+          teamId: team.id,
+          playerId: p.id
+        }))
+      );
+      if (flattened.length) return flattened;
+    }
     if (!user) return PLAYER_PLACEHOLDERS;
-    // TODO: Replace default avatar with user-provided image when backend exposes it.
     return [
       {
         ...PLAYER_PLACEHOLDERS[0],
         playerName: user.username || PLAYER_PLACEHOLDERS[0].playerName,
         avatar: PLAYER_PLACEHOLDERS[0].avatar,
+        playerId: user._id,
+        teamId: 'host-team'
       },
       ...PLAYER_PLACEHOLDERS.slice(1),
     ];
-  }, [user]);
+  }, [session, user]);
+
+  const timerOverrides = useMemo(() => {
+    const s = session?.settings || {};
+    const map = {};
+    if (s.timerFaceoffBuzz) map.faceoffBuzz = Number(s.timerFaceoffBuzz);
+    if (s.timerFaceoffAnswer) map.faceoffAnswer = Number(s.timerFaceoffAnswer);
+    if (s.timerPlayGuess) map.playGuess = Number(s.timerPlayGuess);
+    if (s.timerSteal) map.steal = Number(s.timerSteal);
+    return Object.values(map).length ? map : null;
+  }, [session?.settings]);
+  const timersEnabled = session?.settings?.useTimers !== false;
+
+  const playersWithIds = players;
+
+  useEffect(() => {
+    const loadSession = async () => {
+      setLoadStatus({ state: 'loading', message: 'Loading session…' });
+      try {
+        const res = await sessions.get(sessionId);
+        if (res.status === 401 || res.status === 403) {
+          navigate('/signin');
+          return;
+        }
+        if (!res.ok) throw new Error('Failed to load session');
+        const data = await res.json();
+        setSession(data);
+        const derivedState = buildSessionState(data, flattenPlayers(data));
+        setSessionState(derivedState);
+        setAnnouncement(deriveAnnouncement(data));
+        if (data.currentQuestionId && data.currentQuestionText) {
+          setInitialRound({
+            _id: data.currentQuestionId,
+            question: data.currentQuestionText,
+            size: data.currentQuestionSize
+          });
+          setLastQuestionId(data.currentQuestionId);
+        }
+        setLoadStatus({ state: 'idle', message: '' });
+      } catch (err) {
+        console.error('Failed to load session', err);
+        setSession(null);
+        setLoadStatus({ state: 'error', message: err.message });
+      }
+    };
+    if (sessionId) loadSession();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId, players.length]);
+
+  useEffect(() => {
+    const socket = io(SERVER_URL);
+    websocketRef.current = socket;
+    setConnectedUsers([]);
+
+    socket.on('connect_error', () => setSocketStatus('disconnected'));
+    socket.on('disconnect', () => setSocketStatus('disconnected'));
+    socket.on('connect', () => setSocketStatus('connected'));
+
+    socket.on('connect', () => {
+      console.log('Connected to WebSocket server with ID:', socket.id);
+    });
+
+    socket.on('session:state', async (payload) => {
+      if (payload?.deleted) {
+        navigate('/dashboard');
+        return;
+      }
+      setSession(payload);
+      const derivedState = buildSessionState(payload, flattenPlayers(payload));
+      setSessionState(derivedState);
+      setAnnouncement(deriveAnnouncement(payload));
+      if (
+        payload?.currentQuestionId &&
+        payload.currentQuestionText &&
+        payload.currentQuestionId !== lastQuestionId
+      ) {
+        setInitialRound({
+          _id: payload.currentQuestionId,
+          question: payload.currentQuestionText,
+          size: payload.currentQuestionSize
+        });
+        setLastQuestionId(payload.currentQuestionId);
+      }
+    });
+
+    if (user) {
+      socket.emit('joinRoom', sessionId, user, (res, resUser) => {
+        console.log(res);
+        setConnectedUsers((prevUsers) => ([...prevUsers, resUser]));
+      });
+    }
+
+    return () => {
+      socket.removeAllListeners();
+      socket.disconnect();
+      websocketRef.current = null;
+    };
+  }, [user?._id, sessionId]);
+
+  // Above is for Websocket testing purposes only.
 
   const {
     currentRound,
@@ -101,7 +265,106 @@ export default function GameBoard() {
     handleControlChoice,
     advanceRound,
     reloadRound,
-  } = useGameBoardEngine(players);
+  } = useGameBoardEngine(playersWithIds, initialRound, sessionState, {
+    getTeamIdForPlayer: (idx) => playersWithIds[idx]?.teamId,
+    getPlayerIdForIndex: (idx) => playersWithIds[idx]?.playerId,
+    disableAutoLoad: Boolean(sessionId),
+    timerOverrides,
+    timersEnabled,
+    onAction: (payload) => {
+      if (!websocketRef.current) return;
+      const { type, action, ...rest } = payload || {};
+      const actionName = action || type;
+      if (!actionName) return;
+      const actionBody = {
+        sessionId,
+        actorId: user?._id,
+        action: actionName,
+        ...rest
+      };
+      websocketRef.current.emit('session:action', actionBody, (response) => {
+        if (!response?.ok) {
+          setActionStatus({ state: 'error', message: response?.error || 'Action failed' });
+        }
+      });
+    }
+  });
+
+  const myPlayerIndex = useMemo(
+    () => playersWithIds.findIndex((p) => p.playerId === user?._id),
+    [playersWithIds, user?._id]
+  );
+  const isMyActiveId = session?.activePlayerId && user?._id
+    ? session.activePlayerId === user._id
+    : false;
+  const sessionActiveIndex = session?.activePlayerId
+    ? playersWithIds.findIndex((p) => p.playerId === session.activePlayerId)
+    : null;
+  const sessionControlIndex = session?.controlTeamId
+    ? playersWithIds.findIndex((p) => p.teamId === session.controlTeamId)
+    : null;
+  const displayActiveIndex =
+    typeof sessionActiveIndex === 'number' && sessionActiveIndex >= 0
+      ? sessionActiveIndex
+      : (typeof sessionState?.activePlayerIndex === 'number' ? sessionState.activePlayerIndex : activePlayerIndex);
+  const displayControlIndex =
+    typeof sessionControlIndex === 'number' && sessionControlIndex >= 0
+      ? sessionControlIndex
+      : (typeof sessionState?.controlIndex === 'number' ? sessionState.controlIndex : controlPlayer);
+  const isMyControl =
+    typeof displayControlIndex === 'number' && displayControlIndex === myPlayerIndex;
+  const normalizedActiveIndex =
+    typeof displayActiveIndex === 'number' && displayActiveIndex >= 0 ? displayActiveIndex : null;
+  const isMyTurn =
+    normalizedActiveIndex !== null
+      ? normalizedActiveIndex === myPlayerIndex || isMyActiveId
+      : activePlayerIndex === myPlayerIndex || isMyActiveId;
+  const canSubmit =
+    ANSWERING_PHASES.has(phase) &&
+    roundStatus.state === 'idle' &&
+    !isCheckingAnswer &&
+    socketStatus === 'connected' &&
+    (myPlayerIndex === -1 || isMyTurn);
+
+  const emitAction = (payload) => {
+    if (!websocketRef.current) return;
+    const { type, action, ...rest } = payload || {};
+    const actionName = action || type;
+    if (!actionName) return;
+    websocketRef.current.emit('session:action', {
+      sessionId,
+      actorId: user?._id,
+      action: actionName,
+      ...rest
+    }, (response) => {
+      if (!response?.ok) {
+        setActionStatus({ state: 'error', message: response?.error || 'Action failed' });
+      }
+    });
+  };
+
+  const handleAdvanceRound = () => {
+    if (session) {
+      const nextRoundType = String((session?.currentRound || 0) + 1);
+      emitAction({ type: 'startRound', roundType: nextRoundType });
+    } else {
+      advanceRound();
+    }
+  };
+
+  const handleRestartSession = () => {
+    if (!sessionId || !websocketRef.current) return;
+    if (!window.confirm('Restart the game? This will reset scores/strikes and reload Round 1 for everyone.')) return;
+    emitAction({ type: 'startRound', roundType: '1' });
+  };
+
+  const handleSubmitGuess = (event) => {
+    if (!canSubmit) {
+      event.preventDefault();
+      return;
+    }
+    handleGuessSubmit(event);
+  };
   const [statusDismissed, setStatusDismissed] = useState(false);
   const strikesDisplay = useMemo(
     () => Array.from({ length: 3 }, (_, index) => <span key={index} className={index < strikes ? 'is-hit' : ''}>X</span>),
@@ -125,25 +388,81 @@ export default function GameBoard() {
 
   return (
     <div className="landing-basic game-board">
-      <header className="landing-basic__chrome" />
-      <AdminDrawer
-        open={menuOpen}
-        onToggle={toggleMenu}
-        links={[
-          ...PRIMARY_NAV_LINKS,
-          { path: '/question-sets', label: 'Question Sets' },
-          { path: '/session-create', label: 'Create Session' }
-        ]}
-      />
+      <header className="landing-basic__chrome">
+        <button
+          type="button"
+          className="landing-basic__menu"
+          aria-label="End session"
+          onClick={async () => {
+            if (!sessionId || endStatus.state === 'loading') return;
+            if (!window.confirm('End and delete this session?')) return;
+            setEndStatus({ state: 'loading', message: 'Ending session…' });
+            try {
+              const res = await apiFetch(`/gamesession/${sessionId}`, { method: 'DELETE' });
+              if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                throw new Error(err.message || 'Failed to end session');
+              }
+              navigate('/dashboard');
+            } catch (err) {
+              setEndStatus({ state: 'error', message: err.message });
+            } finally {
+              setEndStatus({ state: 'idle', message: '' });
+            }
+          }}
+          style={{ background: 'rgba(255,0,0,0.15)', borderColor: 'rgba(255,0,0,0.5)' }}
+        >
+          ⏻
+        </button>
+        <button
+          type="button"
+          className="landing-basic__menu"
+          aria-label="Restart session"
+          onClick={handleRestartSession}
+          style={{ background: 'rgba(255,255,0,0.15)', borderColor: 'rgba(200,200,0,0.5)' }}
+        >
+          ⟳
+        </button>
+        <span className={`socket-status socket-status--${socketStatus}`}>
+          {socketStatus === 'connected' ? 'Socket OK' : 'Socket Disconnected'}
+        </span>
+        {announcement ? (
+          <span className="socket-status socket-status--info" style={{ marginLeft: '8px' }}>
+            {announcement}
+          </span>
+        ) : null}
+      </header>
+      {loadStatus.state === 'error' ? (
+        <div className="game-board-round-error" aria-live="assertive">
+          <p>{loadStatus.message || 'Unable to load session.'}</p>
+          <button type="button" onClick={() => window.location.reload()}>Retry</button>
+        </div>
+      ) : null}
+      {actionStatus.state === 'error' ? (
+        <div className="game-board-action-error" aria-live="assertive">
+          <p>{actionStatus.message}</p>
+          <button type="button" onClick={() => setActionStatus({ state: 'idle', message: '' })}>Dismiss</button>
+        </div>
+      ) : null}
+      {isActualAdmin ? (
+        <AdminDrawer
+          open={menuOpen}
+          onToggle={toggleMenu}
+          links={[
+            ...PRIMARY_NAV_LINKS,
+            { path: '/question-sets', label: 'Question Sets' },
+            { path: '/session-create', label: 'Create Session' }
+          ]}
+        />
+      ) : null}
 
       <main className="landing-basic__body game-board__body">
 
-        {/* This is for websocket testing purposes only. */}
-        <div style={{ backgroundColor: 'black', padding: '15px', color: 'white', position: 'absolute', top: '10px', right: '10px', zIndex: 1000, fontSize: '12px' }}>
-          <h2>Connected Users</h2>
+        <div className="game-board-roster" aria-label="Players">
+          <h2>Players</h2>
           <ul>
-            {Object.values(connectedUsers).map((connUser) => (
-              <li key={connUser._id}>{connUser.username} (ID: {connUser._id})</li>
+            {(session?.teams || []).flatMap((team) => team.players || []).map((p) => (
+              <li key={p.id}>{p.name}</li>
             ))}
           </ul>
         </div>
@@ -183,7 +502,7 @@ export default function GameBoard() {
             </div>
           ) : null}
 
-          {roundStatus.state === 'idle' && (phase === 'questionZoom' || phase === 'faceoffBuzz') ? (
+          {roundStatus.state === 'idle' && phase === 'faceoffBuzz' ? (
             <div className="game-board-question-overlay" aria-live="polite">
               <div
                 className="game-board-question-overlay__card"
@@ -269,26 +588,13 @@ export default function GameBoard() {
 
               <div className="game-board-sides" aria-label="Player placeholders">
                 {players.map((player, index) => {
-                  const isActive = index === activePlayerIndex;
-                  const hasControl = controlPlayer === index;
+                  const isActive = index === displayActiveIndex;
+                  const hasControl = displayControlIndex === index;
                   const showPlayControlsForPlayer = showPlayOrPassActions && hasControl;
                   const winnerIndex = roundResult?.winnerIndex;
                   const showAdvanceForPlayer =
                     showRoundAdvanceAction &&
                     (winnerIndex === index || (winnerIndex === null || winnerIndex === undefined ? hasControl : false));
-
-                  let playerMessage = '\u00A0';
-                  if (isActive && feedback) {
-                    playerMessage = feedback;
-                  } else if (!isActive && (phase === 'faceoffBuzz' || phase === 'questionZoom')) {
-                    playerMessage = 'Buzz with spacebar';
-                  } else if (showPlayControlsForPlayer) {
-                    playerMessage = 'Choose play or pass';
-                  } else if (showAdvanceForPlayer) {
-                    playerMessage = phase === 'gameComplete' ? 'Restart the game' : 'Advance to next round';
-                  } else if (isActive) {
-                    playerMessage = activeInstruction;
-                  }
 
                   return (
                     <div
@@ -297,26 +603,23 @@ export default function GameBoard() {
                     >
                       <p className="game-board-player__team">{player.label}</p>
                       <p className="game-board-player__name">{player.playerName}</p>
-                      <p className="game-board-player__status" aria-live={isActive ? 'polite' : undefined}>
-                        {playerMessage}
-                      </p>
                       <div className="game-board-player__avatar" style={{ backgroundImage: `url(${player.avatar})` }} />
                       <div className="game-board-player__score" style={{ backgroundImage: `url(${player.scoreCard})` }}>
                         <span>{String(scores[index]).padStart(3, '0')}</span>
                       </div>
                       {showPlayControlsForPlayer ? (
                         <div className="game-board-player__actions">
-                          <button type="button" onClick={() => handleControlChoice('play')}>
+                          <button type="button" onClick={() => handleControlChoice('play')} disabled={!isMyControl}>
                             Play it
                           </button>
-                          <button type="button" onClick={() => handleControlChoice('pass')}>
+                          <button type="button" onClick={() => handleControlChoice('pass')} disabled={!isMyControl}>
                             Pass it
                           </button>
                         </div>
                       ) : null}
                       {showAdvanceForPlayer ? (
                         <div className="game-board-player__actions">
-                          <button type="button" onClick={advanceRound}>
+                          <button type="button" onClick={handleAdvanceRound}>
                             {phase === 'gameComplete' ? 'Restart game' : 'Next round'}
                           </button>
                         </div>
@@ -327,9 +630,9 @@ export default function GameBoard() {
               </div>
             </div>
 
-            <div className="game-board-console" aria-live="polite">
-              <div className="game-board-input" aria-label="Answer input placeholder">
-                <form className="game-board-answer-form" onSubmit={handleGuessSubmit}>
+              <div className="game-board-console" aria-live="polite">
+                <div className="game-board-input" aria-label="Answer input placeholder">
+                <form className="game-board-answer-form" onSubmit={handleSubmitGuess}>
                   <label className="sr-only" htmlFor="gameboard-guess">
                     Enter guess
                   </label>
@@ -340,18 +643,17 @@ export default function GameBoard() {
                     value={guess}
                     onChange={(event) => setGuess(event.target.value)}
                     placeholder={formPlaceholder}
-                    disabled={
-                      !ANSWERING_PHASES.has(phase) || roundStatus.state !== 'idle' || isCheckingAnswer
-                    }
+                    disabled={!canSubmit}
                   />
                   <button
                     type="submit"
-                    disabled={
-                      !ANSWERING_PHASES.has(phase) || roundStatus.state !== 'idle' || isCheckingAnswer
-                    }
+                    disabled={!canSubmit}
                   >
                     Lock In
                   </button>
+                  {!isMyTurn && myPlayerIndex !== -1 ? (
+                    <p className="form-status">Waiting for your turn…</p>
+                  ) : null}
                 </form>
               </div>
             </div>

--- a/client/src/pages/Lobby.jsx
+++ b/client/src/pages/Lobby.jsx
@@ -1,0 +1,346 @@
+/**
+ * @file Lobby.jsx
+ * @purpose Host-ready lobby so teams can name themselves, ready up, and launch the game.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import PageSection from '../components/PageSection.jsx';
+import { apiFetch, sessions } from '../utils/api.js';
+import { useAuth } from '../components/auth/AuthContext.js';
+import { io } from 'socket.io-client';
+
+const SERVER_URL = import.meta.env.PROD
+  ? (import.meta.env.VITE_SERVER_URL || '')
+  : (import.meta.env.VITE_LOCAL_URL || 'http://localhost:3000');
+
+export default function Lobby() {
+  const { sessionId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [session, setSession] = useState(null);
+  const [status, setStatus] = useState({ state: 'idle', message: '' });
+  const [loading, setLoading] = useState(true);
+  const [teamEdits, setTeamEdits] = useState({});
+  const [joinMessage, setJoinMessage] = useState('');
+  const socketRef = useRef(null);
+
+  const loadSession = async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch(`/gamesession/${sessionId}`, { method: 'GET' });
+      if (res.status === 401 || res.status === 403) {
+        navigate('/signin');
+        return;
+      }
+      if (!res.ok) throw new Error('Failed to load session');
+      const data = await res.json();
+      setSession(data);
+      // auto-join first team if not present
+      if (user?._id && !(data.teams || []).some((t) => (t.players || []).some((p) => p.id === user._id))) {
+        const joinRes = await sessions.join(sessionId, { name: user.username });
+        if (joinRes.ok) {
+          const joined = await joinRes.json();
+          setSession(joined);
+        }
+      }
+      setTeamEdits(
+        (data.teams || []).reduce((acc, team) => {
+          acc[team.id] = team.name || '';
+          return acc;
+        }, {})
+      );
+    } catch (err) {
+      setStatus({ state: 'error', message: err.message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSession();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
+
+  // Subscribe to session updates via socket to auto-navigate when game starts
+  useEffect(() => {
+    const socket = io(SERVER_URL);
+    socketRef.current = socket;
+
+    const performJoin = () => {
+      if (user) {
+        socket.emit('joinRoom', sessionId, user, (msg) => {
+          if (msg && typeof msg === 'string' && msg.toLowerCase().includes('unauthorized')) {
+            setStatus({ state: 'error', message: msg });
+          }
+        });
+      }
+    };
+    performJoin();
+
+    socket.on('connect', performJoin);
+
+    const handleSessionUpdate = async (payload) => {
+      setSession(payload);
+      setTeamEdits(
+        (payload?.teams || []).reduce((acc, team) => {
+          acc[team.id] = team.name || '';
+          return acc;
+        }, {})
+      );
+      if (payload?.status === 'in_progress') {
+        navigate(`/game-board?sessionId=${sessionId}`);
+      }
+    };
+
+    const fetchAndSet = async () => {
+      try {
+        const res = await apiFetch(`/gamesession/${sessionId}`, { method: 'GET' });
+        if (res.ok) {
+          const data = await res.json();
+          await handleSessionUpdate(data);
+        }
+      } catch (err) {
+        // ignore
+      }
+    };
+
+    socket.on('session:state', handleSessionUpdate);
+    socket.on('userJoined', fetchAndSet);
+    socket.on('userLeft', fetchAndSet);
+    socket.on('connect_error', () => {
+      setStatus({ state: 'error', message: 'Socket connection failed. Retrying…' });
+    });
+
+    return () => {
+      socket.removeAllListeners();
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, [navigate, sessionId, user?._id]);
+
+  const updateTeam = async (teamId, payload) => {
+    try {
+      const res = await apiFetch(`/gamesession/${sessionId}/team/${teamId}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) throw new Error('Failed to update team');
+      const data = await res.json();
+      setSession(data);
+    } catch (err) {
+      setStatus({ state: 'error', message: err.message });
+    }
+  };
+
+  const toggleReady = (teamId, ready) => updateTeam(teamId, { ready });
+
+  const renameTeam = async (teamId) => {
+    const name = teamEdits[teamId] ?? '';
+    await updateTeam(teamId, { name });
+  };
+
+  const togglePlayerReady = async (playerId, ready) => {
+    try {
+      const res = await apiFetch(`/gamesession/${sessionId}/player/${playerId}/ready`, {
+        method: 'PUT',
+        body: JSON.stringify({ ready })
+      });
+      if (!res.ok) throw new Error('Failed to update ready state');
+      const data = await res.json();
+      setSession(data);
+    } catch (err) {
+      setStatus({ state: 'error', message: err.message });
+    }
+  };
+
+  const startGame = async () => {
+    if (!session) return;
+    setStatus({ state: 'loading', message: 'Starting game…' });
+    try {
+      const res = await sessions.start(sessionId, '1');
+      if (!res.ok) throw new Error('Failed to start game');
+      navigate(`/game-board?sessionId=${sessionId}`);
+    } catch (err) {
+      setStatus({ state: 'error', message: err.message });
+    } finally {
+      setStatus({ state: 'idle', message: '' });
+    }
+  };
+
+  const cancelSession = async () => {
+    if (!window.confirm('Cancel and delete this session?')) return;
+    setStatus({ state: 'loading', message: 'Canceling…' });
+    try {
+      const res = await apiFetch(`/gamesession/${sessionId}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to cancel session');
+      navigate('/dashboard');
+    } catch (err) {
+      setStatus({ state: 'error', message: err.message });
+    } finally {
+      setStatus({ state: 'idle', message: '' });
+    }
+  };
+
+  const allPlayersReady = session?.teams?.flatMap((t) => t.players || []).length > 0
+    && session.teams.flatMap((t) => t.players || []).every((p) => p.ready);
+  const allReady = allPlayersReady;
+
+  const currentTeamId = useMemo(() => {
+    if (!user?._id || !session?.teams) return null;
+    const team = session.teams.find((t) => (t.players || []).some((p) => p.id === user._id));
+    return team?.id ?? null;
+  }, [session, user]);
+
+  const joinTeam = async (teamId) => {
+    try {
+      const res = await sessions.join(sessionId, { name: user?.username, teamId });
+      if (!res.ok) throw new Error('Failed to join team');
+      const data = await res.json();
+      setSession(data);
+      setJoinMessage(`Joined ${teamId}`);
+      socketRef.current?.emit('joinRoom', sessionId, user, () => {});
+    } catch (err) {
+      setJoinMessage(err.message);
+    }
+  };
+
+  const leaveParty = async () => {
+    try {
+      const res = await apiFetch(`/gamesession/${sessionId}/player-leave`, { method: 'POST' });
+      if (!res.ok) throw new Error('Failed to leave session');
+      const data = await res.json();
+      setSession(data);
+      setJoinMessage('You left the session.');
+      navigate('/dashboard');
+    } catch (err) {
+      setStatus({ state: 'error', message: err.message });
+    }
+  };
+
+  useEffect(() => {
+    if (allReady && status.state === 'idle' && session?.hostUserId === user?._id) {
+      startGame();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allReady, session?.hostUserId, user?._id]);
+
+  if (loading) {
+    return <div className="page page--stacked"><div className="loading-message">Loading lobby…</div></div>;
+  }
+
+  if (!session) {
+    return <div className="page page--stacked"><div className="error-message">Session not found.</div></div>;
+  }
+
+  return (
+    <div className="page page--stacked lobby">
+      <header className="page__header lobby__hero">
+        <div>
+          <p className="eyebrow">Session Lobby</p>
+          <h2>Ready up teams</h2>
+          <p>Session ID: {session.id}</p>
+        </div>
+        <div className="lobby__pill">
+          Access Code <strong>{session.accessCode}</strong>
+        </div>
+      </header>
+
+      {status.state === 'error' ? (
+        <div className="error-message">{status.message}</div>
+      ) : null}
+
+      <div className="lobby-grid">
+        <PageSection title="Teams" description="Name teams and ready up.">
+        <div className="table-placeholder">
+            <div className="lobby-teams__head">
+              <span>Team</span>
+              <span>Players</span>
+              <span>Ready</span>
+            </div>
+            {(session.teams || []).map((team) => (
+              <div key={team.id} className="lobby-teams__row">
+                <div className="lobby-teams__team">
+                  <input
+                    type="text"
+                    value={teamEdits[team.id] ?? team.name}
+                    onChange={(e) => setTeamEdits((prev) => ({ ...prev, [team.id]: e.target.value }))}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        renameTeam(team.id);
+                      }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="lobby__save-btn"
+                    onClick={() => renameTeam(team.id)}
+                    aria-label="Save team name"
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    className="link-button"
+                    disabled={currentTeamId === team.id}
+                    onClick={() => joinTeam(team.id)}
+                  >
+                    {currentTeamId === team.id ? 'You are here' : 'Join team'}
+                  </button>
+                </div>
+                <div className="lobby-teams__players">
+                  {(team.players || []).map((p) => (
+                    <span key={p.id} className="lobby__player-name">
+                      {p.name}
+                  </span>
+                ))}
+              </div>
+              <div className="lobby-teams__ready">
+                {(team.players || []).map((p) => {
+                  const canToggle = user?._id && (user._id === p.id);
+                  return (
+                    <label key={p.id} className="lobby__ready-toggle">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(p.ready)}
+                        disabled={!canToggle}
+                        onChange={(e) => togglePlayerReady(p.id, e.target.checked)}
+                      />
+                      <span className={p.ready ? 'ready' : 'not-ready'}>
+                        {p.ready ? 'Ready' : 'Waiting'}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </PageSection>
+
+        <div className="lobby__sidebar">
+          <PageSection title="Game Settings" description="Snapshot of session settings.">
+            <pre className="lobby__settings">
+              {JSON.stringify(session.settings || {}, null, 2)}
+            </pre>
+          </PageSection>
+
+          <PageSection title="Start" description="Launch when everyone is ready.">
+            <button type="button" onClick={startGame} disabled={!allReady || status.state === 'loading'}>
+              {status.state === 'loading' ? 'Starting…' : allReady ? 'Start Game' : 'Waiting for ready'}
+            </button>
+            <button type="button" className="link-button link-button--destructive" onClick={cancelSession} disabled={status.state === 'loading'}>
+              Cancel Session
+            </button>
+            <button type="button" className="link-button" onClick={leaveParty} disabled={status.state === 'loading'}>
+              Leave Session
+            </button>
+            {joinMessage ? (
+              <p className="form-status" role="status">{joinMessage}</p>
+            ) : null}
+          </PageSection>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/SessionCreate.jsx
+++ b/client/src/pages/SessionCreate.jsx
@@ -11,7 +11,6 @@ import { apiFetch, sessions } from '../utils/api.js';
 import { useAuth } from '../components/auth/AuthContext.js';
 
 const generateId = () => `sess-${Date.now()}-${Math.floor(Math.random() * 1e5)}`;
-const generateCode = () => String(Math.floor(100000 + Math.random() * 900000));
 
 export default function SessionCreate() {
   const navigate = useNavigate();
@@ -21,7 +20,7 @@ export default function SessionCreate() {
   const [formData, setFormData] = useState({
     hostName: user?.username || 'Host',
     questionSetId: 'default',
-    accessCode: generateCode(),
+    accessCode: '',
     id: generateId()
   });
   const [settings, setSettings] = useState({
@@ -76,8 +75,8 @@ export default function SessionCreate() {
       const payload = {
         id: formData.id || generateId(),
         hostName: user?.username || formData.hostName || 'Host',
-        accessCode: formData.accessCode || generateCode(),
-        questionSetId: formData.questionSetId === 'default' ? undefined : formData.questionSetId,
+        accessCode: formData.accessCode || '',
+        questionSetId: formData.questionSetId === 'default' ? 'default' : formData.questionSetId,
         teams: [],
         settings
       };
@@ -88,7 +87,7 @@ export default function SessionCreate() {
       }
       // TODO: save settings per user when backend supports it (e.g., /api/v1/user/:id/settings)
       setStatus({ state: 'success', message: 'Session created' });
-      navigate('/sessions');
+      navigate(`/lobby/${payload.id}`);
     } catch (err) {
       setStatus({ state: 'error', message: err.message });
     }
@@ -156,8 +155,7 @@ export default function SessionCreate() {
               name="accessCode"
               value={formData.accessCode}
               onChange={handleChange}
-              required
-              placeholder="6-digit code"
+              placeholder="Optional: set a code or leave blank for open lobby"
             />
           </label>
 

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -382,6 +382,131 @@ button:focus-visible {
   color: #0f172a;
 }
 
+.lobby__hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.lobby__pill {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: #0ea5e9;
+  color: #fff;
+  font-weight: 700;
+}
+
+.lobby-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem;
+}
+
+.lobby__team-row {
+  align-items: flex-start;
+}
+
+.lobby__team-name {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.lobby-teams__head {
+  display: grid;
+  grid-template-columns: 1.1fr 1.2fr 0.8fr;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: #e2e8f0;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.lobby-teams__row {
+  display: grid;
+  grid-template-columns: 1.1fr 1.2fr 0.8fr;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  align-items: center;
+}
+
+.lobby-teams__team {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.lobby__save-btn {
+  border-radius: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  background: #1d4ed8;
+  color: #fff;
+  padding: 0.4rem 0.65rem;
+  font-weight: 600;
+}
+
+.lobby-teams__players {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.lobby__player-name {
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: inline-flex;
+}
+
+.lobby-teams__ready {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.lobby__ready-toggle {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.lobby__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.lobby__settings {
+  background: #000;
+  color: #0ff;
+  padding: 1rem;
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+@media (max-width: 900px) {
+  .lobby-grid {
+    grid-template-columns: 1fr;
+  }
+  .lobby-teams__head,
+  .lobby-teams__row {
+    grid-template-columns: 1fr;
+  }
+}
+
 .session-card {
   display: flex;
   flex-direction: column;
@@ -759,6 +884,38 @@ button:focus-visible {
 
 .game-board-round-error button:hover {
   background: #ff8787;
+}
+
+.socket-status {
+  position: fixed;
+  top: 0.75rem;
+  right: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.85rem;
+  background: #e5e7eb;
+  color: #111;
+}
+.socket-status--connected {
+  background: #dcfce7;
+  color: #166534;
+}
+.socket-status--disconnected {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.game-board-action-error {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: #fee2e2;
+  color: #991b1b;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+  z-index: 10000;
 }
 
 .game-board-question-overlay {

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -81,5 +81,16 @@ export const sessions = {
     apiFetch('/gamesession', {
       method: 'POST',
       body: JSON.stringify(payload)
+    }),
+  get: (id) => apiFetch(`/gamesession/${id}`, { method: 'GET' }),
+  start: (id, roundType = '1') =>
+    apiFetch(`/gamesession/${id}/start`, {
+      method: 'POST',
+      body: JSON.stringify({ roundType })
+    }),
+  join: (id, payload) =>
+    apiFetch(`/gamesession/${id}/player-join`, {
+      method: 'POST',
+      body: JSON.stringify(payload)
     })
 };

--- a/server/controllers/gameSession.controller.js
+++ b/server/controllers/gameSession.controller.js
@@ -1,25 +1,82 @@
 import ActiveSessionModel from '../models/activeSession.model.js';
 import QuestionModel from '../models/question.model.js';
 import { ROUND_BUCKETS } from './question.controller.js';
+import { seedSessionLog, logSessionEvent } from '../utils/logger.js';
+import GameLog from '../models/gameLog.model.js';
+import { broadcastSession } from '../sockets/sessionBus.js';
+import mongoose from 'mongoose';
 
 const findTeamById = (session, teamId) =>
   session?.teams?.find((team) =>
     team?._id?.toString() === teamId || team?.id === teamId
   );
 
+const findQuestionForRound = async (roundType) => {
+  const roundBucket = ROUND_BUCKETS[roundType];
+  if (!roundBucket) throw new Error('Invalid round type');
+  const { minAnswers, maxAnswers } = roundBucket;
+  const questionQuery = {};
+  if (minAnswers) questionQuery['answers.' + (minAnswers - 1)] = { $exists: true };
+  if (maxAnswers) questionQuery['answers.' + maxAnswers] = { $exists: false };
+
+  let count = await QuestionModel.countDocuments(questionQuery);
+  if (count === 0) throw new Error('No questions available for this round');
+
+  const randomIndex = Math.floor(Math.random() * count);
+  const question = await QuestionModel.findOne(questionQuery).skip(randomIndex);
+  if (!question) throw new Error('Question not found');
+  return question;
+};
+
 // Create a new game session
 export const createGameSession = async (req, res) => {
   try {
-    const { id, hostName, accessCode, questionSetId, teams } = req.body;
+    const { id, hostName, accessCode, questionSetId, teams, settings } = req.body;
+    const hostId = req.auth?._id?.toString() || 'host';
+    const hostLabel = req.user?.displayName || req.user?.username || hostName || 'Host';
+
+    const baseTeams = Array.isArray(teams) && teams.length ? teams : [
+      { id: 'team-a', name: 'Team A', players: [], ready: false, score: 0, strikes: 0 },
+      { id: 'team-b', name: 'Team B', players: [], ready: false, score: 0, strikes: 0 }
+    ];
+
+    const normalizedTeams = (() => {
+      const copy = baseTeams.map((team, index) => ({
+        id: team.id || `team-${index + 1}`,
+        name: team.name || `Team ${index + 1}`,
+        players: Array.isArray(team.players) ? team.players : [],
+        ready: Boolean(team.ready),
+        score: Number(team.score) || 0,
+        strikes: Number(team.strikes) || 0
+      }));
+      // ensure host is on a team
+      if (!copy.some((t) => t.players?.some((p) => p.id === hostId))) {
+        if (!copy[0]) {
+          copy[0] = { id: 'team-a', name: 'Team A', players: [], ready: false, score: 0, strikes: 0 };
+        }
+        copy[0].players = [...(copy[0].players || []), { id: hostId, name: hostLabel, ready: false }];
+      }
+      return copy;
+    })();
+
     const newSession = new ActiveSessionModel({
       id,
       hostName,
+      hostUserId: hostId,
       accessCode,
       questionSetId,
-      teams: teams || [],
+      teams: normalizedTeams,
       status: 'lobby',
+      settings: settings || {}
     });
     await newSession.save();
+    await seedSessionLog(id, {
+      hostId: req.auth?._id?.toString(),
+      settings: settings || {},
+      teams: normalizedTeams
+    });
+    await logSessionEvent(id, { event: 'SESSION_CREATED', actorId: req.auth?._id?.toString(), payload: { hostName, accessCode, questionSetId } });
+    broadcastSession(id, newSession);
     res.status(201).json(newSession);
   } catch (error) {
     res.status(500).json({ message: error.message });
@@ -48,6 +105,8 @@ export const updateGameSession = async (req, res) => {
       { new: true }
     );
     if (!session) return res.status(404).json({ message: 'Session not found' });
+    await logSessionEvent(id, { event: 'SESSION_UPDATED', actorId: req.auth?._id?.toString(), payload: updates });
+    broadcastSession(id, session);
     res.status(200).json(session);
   } catch (error) {
     res.status(500).json({ message: error.message });
@@ -62,25 +121,68 @@ export const startRound = async (req, res) => {
     const session = await ActiveSessionModel.findOne({ id });
     if (!session) return res.status(404).json({ message: 'Session not found' });
 
-    const roundBucket = ROUND_BUCKETS[roundType];
-    if (!roundBucket) return res.status(400).json({ message: 'Invalid round type' });
-
-    const { minAnswers, maxAnswers } = roundBucket;
-    const questionQuery = {};
-    if (minAnswers) questionQuery['answers.' + (minAnswers - 1)] = { $exists: true };
-    if (maxAnswers) questionQuery['answers.' + maxAnswers] = { $exists: false };
-
-    const count = await QuestionModel.countDocuments(questionQuery);
-    if (count === 0) return res.status(404).json({ message: 'No questions available for this round' });
-
-    const randomIndex = Math.floor(Math.random() * count);
-    const question = await QuestionModel.findOne(questionQuery).skip(randomIndex);
-    if (!question) return res.status(404).json({ message: 'Question not found' });
+    const question = await findQuestionForRound(roundType);
 
     session.currentRound += 1;
     session.status = 'in_progress';
     session.updatedAt = new Date();
+    session.currentQuestionId = question._id.toString();
+    session.currentQuestionText = question.question;
+    session.currentQuestionSize = question.answers?.length ?? null;
+    session.revealedAnswers = (question.answers || []).map((ans, idx) => ({
+      index: idx,
+      answer: ans.answer,
+      points: ans.points,
+      revealed: false
+    }));
+    session.controlTeamId = null;
     await session.save();
+    await logSessionEvent(id, { event: 'ROUND_STARTED', actorId: req.auth?._id?.toString(), payload: { round: session.currentRound, questionId: question._id, roundType } });
+    broadcastSession(id, session);
+
+    res.status(200).json({
+      session,
+      question: {
+        _id: question._id,
+        question: question.question,
+        size: question.answers.length,
+      },
+    });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+// Start session and first round
+export const startSession = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { roundType = '1' } = req.body;
+    const session = await ActiveSessionModel.findOne({ id });
+    if (!session) return res.status(404).json({ message: 'Session not found' });
+    // enforce all players ready
+    const allPlayersReady = session.teams.flatMap((t) => t.players || []).length > 0 &&
+      session.teams.flatMap((t) => t.players || []).every((p) => p.ready);
+    if (!allPlayersReady) return res.status(400).json({ message: 'All players must be ready before starting.' });
+
+    const question = await findQuestionForRound(roundType);
+    session.status = 'in_progress';
+    session.currentRound = 1;
+    session.currentQuestionId = question._id.toString();
+    session.currentQuestionText = question.question;
+    session.currentQuestionSize = question.answers?.length ?? null;
+    session.revealedAnswers = (question.answers || []).map((ans, idx) => ({
+      index: idx,
+      answer: ans.answer,
+      points: ans.points,
+      revealed: false
+    }));
+    session.controlTeamId = null;
+    session.updatedAt = new Date();
+    await session.save();
+
+    await logSessionEvent(id, { event: 'SESSION_STARTED', actorId: req.auth?._id?.toString(), payload: { roundType, questionId: question._id } });
+    broadcastSession(id, session);
 
     res.status(200).json({
       session,
@@ -99,7 +201,7 @@ export const startRound = async (req, res) => {
 export const updateTeam = async (req, res) => {
   try {
     const { id, teamId } = req.params;
-    const { score, strikes } = req.body;
+    const { score, strikes, ready, name, players } = req.body;
     const session = await ActiveSessionModel.findOne({ id });
     if (!session) return res.status(404).json({ message: 'Session not found' });
 
@@ -108,9 +210,45 @@ export const updateTeam = async (req, res) => {
 
     if (score !== undefined) team.score = score;
     if (strikes !== undefined) team.strikes = strikes;
+    if (ready !== undefined) team.ready = ready;
+    if (name !== undefined) team.name = name;
+    if (Array.isArray(players)) team.players = players;
 
     session.updatedAt = new Date();
     await session.save();
+    await logSessionEvent(id, { event: 'TEAM_UPDATED', actorId: req.auth?._id?.toString(), payload: { teamId, score, strikes, ready, name, players } });
+    broadcastSession(id, session);
+    res.status(200).json(session);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+// Update player ready state (only that player)
+export const updatePlayerReady = async (req, res) => {
+  try {
+    const { id, playerId } = req.params;
+    const { ready } = req.body;
+    const session = await ActiveSessionModel.findOne({ id });
+    if (!session) return res.status(404).json({ message: 'Session not found' });
+
+    let targetPlayer = null;
+    session.teams?.forEach((team) => {
+      team.players?.forEach((p) => {
+        if (p.id === playerId || p._id?.toString() === playerId) targetPlayer = p;
+      });
+    });
+    if (!targetPlayer) return res.status(404).json({ message: 'Player not found' });
+
+    if (req.auth?._id?.toString() !== playerId && !req.user?.admin) {
+      return res.status(403).json({ message: 'Not authorized to update this player' });
+    }
+
+    targetPlayer.ready = Boolean(ready);
+    session.updatedAt = new Date();
+    await session.save();
+    await logSessionEvent(id, { event: 'PLAYER_READY_UPDATED', actorId: req.auth?._id?.toString(), payload: { playerId, ready: Boolean(ready) } });
+    broadcastSession(id, session);
     res.status(200).json(session);
   } catch (error) {
     res.status(500).json({ message: error.message });
@@ -127,22 +265,44 @@ export const getAllGameSessions = async (req, res) => {
   }
 };
 
+// Delete a game session (lobby cancel)
+export const deleteGameSession = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const session = await ActiveSessionModel.findOneAndDelete({ id });
+    if (!session) return res.status(404).json({ message: 'Session not found' });
+    await logSessionEvent(id, { event: 'SESSION_DELETED', actorId: req.auth?._id?.toString(), payload: {} });
+    await GameLog.deleteOne({ sessionId: id }).catch(() => {});
+    broadcastSession(id, { deleted: true, id });
+    res.status(200).json({ message: 'Session deleted' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
 
 // Reveal next answer
 export const revealAnswer = async (req, res) => {
   try {
     const { id } = req.params;
+    const { index } = req.body;
     const session = await ActiveSessionModel.findOne({ id });
     if (!session) return res.status(404).json({ message: 'Session not found' });
 
-    // Logic to reveal the next answer
-    const updatedSession = await ActiveSessionModel.findOneAndUpdate(
-      { id },
-      { /* update fields */ },
-      { new: true }
-    );
+    if (typeof index !== 'number' || index < 0 || index >= (session.currentQuestionSize || 0)) {
+      return res.status(400).json({ message: 'Invalid answer index' });
+    }
 
-    res.status(200).json(updatedSession);
+    session.revealedAnswers = session.revealedAnswers || [];
+    const target = session.revealedAnswers.find((a) => a.index === index);
+    if (target) target.revealed = true;
+    session.updatedAt = new Date();
+    await session.save();
+
+    await logSessionEvent(id, { event: 'ANSWER_REVEALED', actorId: req.auth?._id?.toString(), payload: { index } });
+    broadcastSession(id, session);
+
+    res.status(200).json(session);
   } catch (error) {
     res.status(500).json({ message: error.message });
   }
@@ -162,10 +322,145 @@ export const addStrike = async (req, res) => {
     session.updatedAt = new Date();
     await session.save();
 
+    await logSessionEvent(id, { event: 'STRIKE_ADDED', actorId: req.auth?._id?.toString(), payload: { teamId } });
+    broadcastSession(id, session);
     res.status(200).json(session);
   } catch (error) {
     res.status(500).json({ message: error.message });
   }
+};
+
+const normalizeText = (value = '') => value.toString().trim().toLowerCase();
+
+// Socket-compatible action handler
+export const handleSocketAction = async ({
+  action,
+  type,
+  sessionId,
+  teamId,
+  points,
+  index,
+  actorId,
+  roundType,
+  playerId,
+  guess
+}) => {
+  const actionName = action || type;
+  const session = await ActiveSessionModel.findOne({ id: sessionId });
+  if (!session) throw new Error('Session not found');
+
+  const isHost = !session.hostUserId || session.hostUserId === actorId;
+  const isMember = session.teams?.some((t) => (t.players || []).some((p) => p.id === actorId));
+  if (!isMember) throw new Error('Not a session participant');
+  const hostOnly = new Set(['startRound', 'endRound']);
+  if (hostOnly.has(actionName) && !isHost) {
+    throw new Error('Host privileges required for this action');
+  }
+
+  if (actionName === 'strike' || actionName === 'addStrike') {
+    const targetTeamId = teamId || session.controlTeamId;
+    const team = findTeamById(session, targetTeamId);
+    if (!team) throw new Error('Team not found');
+    team.strikes = (team.strikes || 0) + 1;
+  }
+
+  if (actionName === 'awardPoints') {
+    const team = findTeamById(session, teamId);
+    if (!team) throw new Error('Team not found');
+    team.score += Number(points) || 0;
+  }
+
+  if (actionName === 'setControl') {
+    session.controlTeamId = teamId;
+  }
+
+  if (actionName === 'setActivePlayer') {
+    session.activePlayerId = playerId || actorId || null;
+  }
+
+  if (actionName === 'buzz') {
+    session.activePlayerId = actorId || null;
+  }
+
+  if (actionName === 'playPass') {
+    if (teamId) session.controlTeamId = teamId;
+    session.activePlayerId = playerId || actorId || session.activePlayerId;
+  }
+
+  if (actionName === 'revealAnswer') {
+    session.revealedAnswers = session.revealedAnswers || [];
+    if (typeof index === 'number' && index >= 0 && index < (session.currentQuestionSize || 0)) {
+      session.revealedAnswers = session.revealedAnswers.map((entry) =>
+        entry.index === index
+          ? {
+            ...entry,
+            revealed: true,
+            answer: entry.answer || guess || entry.answer,
+            points: entry.points || points
+          }
+          : entry
+      );
+    }
+  }
+
+  if (actionName === 'submitGuess') {
+    const cleaned = normalizeText(guess);
+    if (!cleaned) throw new Error('Guess is required');
+    const answers = session.revealedAnswers || [];
+    const match = answers.find((ans) => normalizeText(ans.answer) === cleaned);
+    if (match) {
+      session.revealedAnswers = answers.map((entry) =>
+        entry.index === match.index ? { ...entry, revealed: true } : entry
+      );
+    } else {
+      const targetTeamId = teamId || session.controlTeamId;
+      const team = findTeamById(session, targetTeamId);
+      if (team) team.strikes = (team.strikes || 0) + 1;
+    }
+  }
+
+  if (actionName === 'startRound') {
+    // If roundType === '1', treat as a full restart/reset to round 1.
+    const restarting = String(roundType) === '1';
+    const derivedRound = roundType || String((session.currentRound || 0) + 1);
+    const question = await findQuestionForRound(derivedRound);
+    session.currentRound = restarting ? 1 : (session.currentRound || 0) + 1;
+    session.status = 'in_progress';
+    session.currentQuestionId = question._id.toString();
+    session.currentQuestionText = question.question;
+    session.currentQuestionSize = question.answers?.length ?? null;
+    session.revealedAnswers = (question.answers || []).map((ans, idx) => ({
+      index: idx,
+      answer: ans.answer,
+      points: ans.points,
+      revealed: false
+    }));
+    session.controlTeamId = null;
+    session.activePlayerId = null;
+    if (restarting) {
+      // Reset per-team state on full restart.
+      session.teams = (session.teams || []).map((team) => ({
+        ...team.toObject?.() || team,
+        score: 0,
+        strikes: 0,
+        ready: false
+      }));
+      session.roundResult = null;
+    }
+  }
+
+  if (actionName === 'endRound') {
+    session.currentRound = (session.currentRound || 0) + 1;
+    session.status = 'lobby';
+    session.controlTeamId = null;
+    session.activePlayerId = null;
+  }
+
+  session.updatedAt = new Date();
+  await session.save();
+  await logSessionEvent(sessionId, { event: `SOCKET_${(actionName || 'noop').toUpperCase()}`, actorId, payload: { teamId, points, index } });
+  broadcastSession(sessionId, session);
+  return session;
 };
 
 // Award points
@@ -183,6 +478,8 @@ export const awardPoints = async (req, res) => {
     session.updatedAt = new Date();
     await session.save();
 
+    await logSessionEvent(id, { event: 'POINTS_AWARDED', actorId: req.auth?._id?.toString(), payload: { teamId, points } });
+    broadcastSession(id, session);
     res.status(200).json(session);
   } catch (error) {
     res.status(500).json({ message: error.message });
@@ -201,7 +498,65 @@ export const endRound = async (req, res) => {
     session.updatedAt = new Date();
     await session.save();
 
+    await logSessionEvent(id, { event: 'ROUND_ENDED', actorId: req.auth?._id?.toString(), payload: { round: session.currentRound } });
+    broadcastSession(id, session);
     res.status(200).json(session);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+// Player join
+export const playerJoin = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { name, teamId } = req.body;
+    const session = await ActiveSessionModel.findOne({ id });
+    if (!session) return res.status(404).json({ message: 'Session not found' });
+    const playerId = req.auth?._id?.toString() || `guest-${Date.now()}`;
+    const targetTeam = teamId ? findTeamById(session, teamId) : session.teams?.[0];
+    if (!targetTeam) return res.status(400).json({ message: 'No team available' });
+
+    // remove from any existing team first
+    session.teams.forEach((team) => {
+      team.players = (team.players || []).filter((p) => p.id !== playerId);
+    });
+
+    // prevent duplicate
+    if (!targetTeam.players.some((p) => p.id === playerId)) {
+      targetTeam.players.push({ id: playerId, name: name || 'Player', ready: false });
+    }
+
+    session.updatedAt = new Date();
+    await session.save();
+    await logSessionEvent(id, { event: 'PLAYER_JOINED', actorId: playerId, payload: { teamId: targetTeam.id, name } });
+    const fresh = await ActiveSessionModel.findOne({ id }).lean();
+    broadcastSession(id, fresh || session);
+    res.status(200).json(fresh || session);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+// Player leave
+export const playerLeave = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const playerId = req.auth?._id?.toString();
+    if (!playerId) return res.status(401).json({ message: 'Unauthorized' });
+    const session = await ActiveSessionModel.findOne({ id });
+    if (!session) return res.status(404).json({ message: 'Session not found' });
+
+    session.teams = (session.teams || []).map((team) => ({
+      ...team.toObject?.() || team,
+      players: (team.players || []).filter((p) => p.id !== playerId)
+    }));
+    session.updatedAt = new Date();
+    await session.save();
+    await logSessionEvent(id, { event: 'PLAYER_LEFT', actorId: playerId, payload: {} });
+    const fresh = await ActiveSessionModel.findOne({ id }).lean();
+    broadcastSession(id, fresh || session);
+    res.status(200).json(fresh || session);
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/server/models/activeSession.model.js
+++ b/server/models/activeSession.model.js
@@ -11,6 +11,20 @@ const TeamSchema = new mongoose.Schema({
     trim: true,
     required: "Team name is required"
   },
+  ready: {
+    type: Boolean,
+    default: false
+  },
+  players: {
+    type: [
+      {
+        id: { type: String, required: true },
+        name: { type: String, required: true },
+        ready: { type: Boolean, default: false }
+      }
+    ],
+    default: []
+  },
   score: {
     type: Number,
     default: 0
@@ -32,22 +46,62 @@ const ActiveSessionSchema = new mongoose.Schema({
     trim: true,
     required: "Host name is required"
   },
+  hostUserId: {
+    type: String,
+    default: null,
+    index: true
+  },
+  activePlayerId: {
+    type: String,
+    default: null
+  },
   accessCode: {
     type: String,
-    required: "Access code is required"
+    default: ''
   },
   status: {
     type: String,
-    enum: ['lobby', 'in_progress', 'completed'],
+    enum: ['lobby', 'ready', 'in_progress', 'completed'],
     default: 'lobby'
   },
   questionSetId: {
     type: String,
     required: "Question set ID is required"
   },
+  settings: {
+    type: Object,
+    default: {}
+  },
   teams: {
     type: [TeamSchema],
     default: []
+  },
+  controlTeamId: {
+    type: String,
+    default: null
+  },
+  revealedAnswers: {
+    type: [
+      {
+        index: Number,
+        answer: String,
+        points: Number,
+        revealed: { type: Boolean, default: false }
+      }
+    ],
+    default: []
+  },
+  currentQuestionId: {
+    type: String,
+    default: null
+  },
+  currentQuestionText: {
+    type: String,
+    default: null
+  },
+  currentQuestionSize: {
+    type: Number,
+    default: null
   },
   currentRound: {
     type: Number,

--- a/server/models/gameLog.model.js
+++ b/server/models/gameLog.model.js
@@ -1,0 +1,38 @@
+import mongoose from 'mongoose';
+
+const LogEntrySchema = new mongoose.Schema({
+  ts: { type: Date, default: Date.now },
+  actorId: { type: String, default: null },
+  actorRole: { type: String, enum: ['host', 'player', 'system', null], default: 'system' },
+  event: { type: String, required: true },
+  payload: { type: Object, default: {} }
+}, { _id: false });
+
+const TeamSummarySchema = new mongoose.Schema({
+  teamId: String,
+  name: String,
+  score: Number,
+  players: [{ id: String, name: String }],
+  pointsByPlayer: [{ playerId: String, points: Number }]
+}, { _id: false });
+
+const RoundSummarySchema = new mongoose.Schema({
+  roundIndex: Number,
+  questionId: String,
+  pointsAwarded: Number,
+  winnerTeamId: String
+}, { _id: false });
+
+const GameLogSchema = new mongoose.Schema({
+  sessionId: { type: String, index: true, required: true },
+  hostId: { type: String },
+  settings: { type: Object, default: {} },
+  createdAt: { type: Date, default: Date.now },
+  entries: { type: [LogEntrySchema], default: [] },
+  final: {
+    teamSummaries: { type: [TeamSummarySchema], default: [] },
+    rounds: { type: [RoundSummarySchema], default: [] }
+  }
+});
+
+export default mongoose.model('GameLog', GameLogSchema);

--- a/server/routes/v1/gamesession.route.js
+++ b/server/routes/v1/gamesession.route.js
@@ -9,7 +9,12 @@ import {
   revealAnswer,
   addStrike,
   awardPoints,
-  endRound
+  endRound,
+  deleteGameSession,
+  updatePlayerReady,
+  startSession,
+  playerJoin,
+  playerLeave
 } from '../../controllers/gameSession.controller.js';
 import authMiddleware from '../../middlewares/auth.middleware.js';
 
@@ -20,9 +25,14 @@ export default Router()
 
   // Protected routes
   .post('/', authMiddleware.requireSignin, createGameSession)
+  .post('/:id/start', authMiddleware.requireSignin, startSession)
+  .post('/:id/player-join', authMiddleware.requireSignin, playerJoin)
+  .post('/:id/player-leave', authMiddleware.requireSignin, playerLeave)
   .put('/:id', authMiddleware.requireSignin, updateGameSession)
+  .delete('/:id', authMiddleware.requireSignin, deleteGameSession)
   .post('/:id/round', authMiddleware.requireSignin, startRound)
   .put('/:id/team/:teamId', authMiddleware.requireSignin, updateTeam)
+  .put('/:id/player/:playerId/ready', authMiddleware.requireSignin, updatePlayerReady)
   .post('/:id/reveal-answer', authMiddleware.requireSignin, revealAnswer)
   .post('/:id/team/:teamId/add-strike', authMiddleware.requireSignin, addStrike)
   .post('/:id/team/:teamId/award-points', authMiddleware.requireSignin, awardPoints)
@@ -30,4 +40,3 @@ export default Router()
 
   // Admin-only routes rethink or refactor
   .get('/', authMiddleware.requireSignin, /*authMiddleware.hasAuthorization,*/ getAllGameSessions)
-

--- a/server/sockets/gameSession.socket.js
+++ b/server/sockets/gameSession.socket.js
@@ -1,9 +1,31 @@
 export const joinGameSession = (socket) => {
 
-    socket.on("joinRoom", (roomId, user, res) => {
-        socket.join(roomId);
-        socket.broadcast.to(roomId).emit("userJoined", user.username);
-        res(`Joined room ${roomId}.`, user);
+    socket.on("joinRoom", async (roomId, user, res) => {
+        if (!user || !user._id) {
+            return res?.(`Unauthorized join attempt.`, null);
+        }
+        try {
+            const sessionMod = await import('../models/activeSession.model.js');
+            const ActiveSession = sessionMod.default;
+            const session = await ActiveSession.findOne({ id: roomId }).lean();
+            const isMember = session?.teams?.some((t) => (t.players || []).some((p) => p.id?.toString() === user._id?.toString()));
+            if (!session) return res?.('Session not found', null);
+            // Allow lobby spectators to join the room to receive updates; enforce membership only after lobby?
+            if (!isMember && session.status !== 'lobby') {
+                return res?.('User not in session.', null);
+            }
+            socket.join(roomId);
+            const fresh = await ActiveSession.findOne({ id: roomId }).lean();
+            if (fresh) {
+                // broadcast full state to everyone in the room, including the joiner
+                socket.to(roomId).emit('session:state', fresh);
+                socket.emit('session:state', fresh);
+            }
+            socket.broadcast.to(roomId).emit("userJoined", user.username);
+            res?.(`Joined room ${roomId}.`, user);
+        } catch (err) {
+            res?.('Failed to join session.', null);
+        }
     });
 
 };
@@ -16,4 +38,20 @@ export const leaveGameSession = (socket) => {
         socket.broadcast.to(roomId).emit("userLeft", user.username);
     });
 
+};
+
+export const registerHostActions = (socket) => {
+    socket.on("session:action", async (payload, res) => {
+        try {
+            const mod = await import('../controllers/gameSession.controller.js');
+            const { handleSocketAction } = mod;
+            const session = await handleSocketAction({
+                ...payload,
+                actorId: payload?.actorId || socket.id
+            });
+            res?.({ ok: true, session });
+        } catch (err) {
+            res?.({ ok: false, error: err.message });
+        }
+    });
 };

--- a/server/sockets/sessionBus.js
+++ b/server/sockets/sessionBus.js
@@ -1,0 +1,10 @@
+let ioRef = null;
+
+export function setIo(io) {
+  ioRef = io;
+}
+
+export function broadcastSession(sessionId, payload) {
+  if (!ioRef || !sessionId) return;
+  ioRef.to(sessionId).emit('session:state', payload);
+}

--- a/server/sockets/websocket.js
+++ b/server/sockets/websocket.js
@@ -1,14 +1,17 @@
 import { Server } from "socket.io";
 import { instrument } from "@socket.io/admin-ui";
-import { joinGameSession, leaveGameSession } from "./gameSession.socket.js";
+import { joinGameSession, leaveGameSession, registerHostActions } from "./gameSession.socket.js";
+import { setIo } from './sessionBus.js';
 
 export default function initWebsocket(listeningPort) {
     const io = new Server();
+    setIo(io);
     io.on("connection", (socket) => {
         console.log("User connected to websocket:", socket.id);
 
         joinGameSession( socket );
         leaveGameSession( socket );
+        registerHostActions( socket );
     });
 
     const ioCorsOptions = {

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,0 +1,39 @@
+import GameLog from '../models/gameLog.model.js';
+
+/**
+ * Appends a structured event to the session log.
+ * @param {string} sessionId
+ * @param {object} entry
+ */
+export async function logSessionEvent(sessionId, entry) {
+  if (!sessionId) return;
+  await GameLog.updateOne(
+    { sessionId },
+    {
+      $push: { entries: { ts: new Date(), actorRole: 'system', ...entry } }
+    }
+  ).catch((err) => {
+    console.error('Failed to append session log', sessionId, err);
+  });
+}
+
+/**
+ * Seeds a new log record for a session.
+ */
+export async function seedSessionLog(sessionId, { hostId, settings, teams }) {
+  if (!sessionId) return null;
+  try {
+    const doc = await GameLog.create({
+      sessionId,
+      hostId,
+      settings,
+      entries: [
+        { event: 'SESSION_CREATED', payload: { settings, teams } }
+      ]
+    });
+    return doc;
+  } catch (err) {
+    console.error('Failed to seed session log', sessionId, err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Stabilize multiplayer: server-authoritative session state (scores, strikes, control, active player, revealed answers) broadcast via sockets; host actions emit over `session:action`; board hydrates from broadcasts.
- Lobby/dashboard UX: open-party sessions (blank access code), join/leave/switch teams, readiness required before start, refresh icon, auto-start navigates all to board, hide admin drawer for non-admins.
- Gameplay resilience: persist/replay reveals/strikes/control/active player, restart resets scores/strikes/control to round 1, timer overrides with “timer off” support, socket room auth tightened; added logging/broadcast helpers (`sessionBus`, `logger`, `gameLog`).
- Fixes: missing placeholder import/asset resolutions and misc layout/state alignment across clients.
